### PR TITLE
Bug 4181 link to readme on rows text area

### DIFF
--- a/app/views/export_card_configurations/_form.html.erb
+++ b/app/views/export_card_configurations/_form.html.erb
@@ -34,11 +34,8 @@ See doc/COPYRIGHT.md for more details.
 <p><%= f.text_field :page_size, :required => true, :value => "A4", :readonly => true %></p>
 <P><%= f.select :orientation, [:landscape, :portrait], :required => true %></p>
 
-<!-- Hack alert: This is stolen from the HTML produced by the work package descripion RTF editor. -->
-<div class="jstElements">
-  <div class="help"><a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open(&quot;https://github.com/finnlabs/openproject-pdf_export#usage&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes&quot;); return false;">Rows Formatting</a></div>
-  <span><br><br></span>
-</div>
+<%= render partial: "rows_format_help" %>
+
 <p>
 <%= f.text_area :rows, :required => true %>
 </p>

--- a/app/views/export_card_configurations/_form.html.erb
+++ b/app/views/export_card_configurations/_form.html.erb
@@ -33,7 +33,15 @@ See doc/COPYRIGHT.md for more details.
 <p><%= f.text_field :per_page, :required => true %></p>
 <p><%= f.text_field :page_size, :required => true, :value => "A4", :readonly => true %></p>
 <P><%= f.select :orientation, [:landscape, :portrait], :required => true %></p>
-<p><%= f.text_area :rows, :required => true, :class => "wiki-edit" %></p>
+
+<!-- Hack alert: This is stolen from the HTML produced by the work package descripion RTF editor. -->
+<div class="jstElements">
+  <div class="help"><a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open(&quot;https://github.com/finnlabs/openproject-pdf_export#usage&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes&quot;); return false;">Rows Formatting</a></div>
+  <span><br><br></span>
+</div>
+<p>
+<%= f.text_area :rows, :required => true %>
+</p>
 
 <!--[eoform:export_card_configuration]-->
 </div>

--- a/app/views/export_card_configurations/_form.html.erb
+++ b/app/views/export_card_configurations/_form.html.erb
@@ -34,11 +34,8 @@ See doc/COPYRIGHT.md for more details.
 <p><%= f.text_field :page_size, :required => true, :value => "A4", :readonly => true %></p>
 <P><%= f.select :orientation, [:landscape, :portrait], :required => true %></p>
 
-<%= render partial: "rows_format_help" %>
-
-<p>
-<%= f.text_area :rows, :required => true %>
-</p>
+<% field = (f.text_area :rows, :required => true, :class => "wiki-edit") %>
+<%= render partial: "rows_format_help", locals: { field: field } %>
 
 <!--[eoform:export_card_configuration]-->
 </div>

--- a/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -1,4 +1,3 @@
-<!-- Hack alert: This is stolen from the HTML produced by the work package descripion RTF editor. -->
 <div class="jstElements">
   <div class="help">
     <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes'); return false;">

--- a/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -1,7 +1,7 @@
 <div class="jstElements">
   <div class="help">
     <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
-      Rows Formatting
+      <%= l('help_link_rows_format') %>
     </a>
   </div>
   <span><br><br></span>

--- a/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -1,8 +1,8 @@
-<div class="jstElements">
-  <div class="help">
-    <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
+<p class="jstElements">
+  <span class="help">
+    <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=850, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
       <%= l('help_link_rows_format') %>
     </a>
-  </div>
-  <span><br><br></span>
-</div>
+  </span>
+  <%= field %>
+</p>

--- a/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -1,0 +1,9 @@
+<!-- Hack alert: This is stolen from the HTML produced by the work package descripion RTF editor. -->
+<div class="jstElements">
+  <div class="help">
+    <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=800, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
+      Rows Formatting
+    </a>
+  </div>
+  <span><br><br></span>
+</div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,3 +38,4 @@ de:
   notice_export_card_configuration_deactivated: "Export-Kartenkonfiguration erfolgreich de-aktiviert"
   error_can_not_activate_export_card_configuration: "Diese Konfiguration kann nicht aktiviert werden"
   error_can_not_deactivate_export_card_configuration: "Diese Konfiguration kann nicht de-aktiviert werden"
+  help_link_rows_format: "Rows formatieren"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,4 @@ en:
   notice_export_card_configuration_deactivated: "Config succesfully de-activated"
   error_can_not_activate_export_card_configuration: "This config cannot be activated"
   error_can_not_deactivate_export_card_configuration: "This config cannot be de-activated"
+  help_link_rows_format: "Rows Formatting"


### PR DESCRIPTION
This is a bit of a hack - I just stole the html from the work package description field which is generated (i think) as part of the rich text editor. If this isn't up to the code standards then i'll try and do something nicer.
