### PR TITLE
Heighest priority row will extend its height to fill group

### DIFF
--- a/lib/open_project/pdf_export/export_card/card_element.rb
+++ b/lib/open_project/pdf_export/export_card/card_element.rb
@@ -73,7 +73,7 @@ module OpenProject::PdfExport::ExportCard
       row_heights = []
 
       groups.each_with_index do |(gk, gv), i|
-        enforced_group_height = gv["height"] || 0
+        enforced_group_height = gv["height"] || -1
         used_group_height = 0
         current_rows = []
 
@@ -81,9 +81,11 @@ module OpenProject::PdfExport::ExportCard
           if rv["height"]
             used_group_height += rv["height"]
             current_rows << { height: rv["height"], group: i, priority: rv["priority"] || 10 }
+            row_heights << { height: rv["height"], group: i, priority: rv["priority"] || 10 }
           else
             used_group_height += min_row_height(rv)
             current_rows << { height: min_row_height(rv), group: i, priority: rv["priority"] || 10 }
+            row_heights << { height: min_row_height(rv), group: i, priority: rv["priority"] || 10 }
           end
         end
 
@@ -92,7 +94,6 @@ module OpenProject::PdfExport::ExportCard
           (current_rows.sort_by{ |r| r[:priority]}.first)[:height] += free_space
         end
 
-        row_heights |= current_rows
         group_heights << [used_group_height, enforced_group_height].max
       end
 

--- a/lib/open_project/pdf_export/export_card/card_element.rb
+++ b/lib/open_project/pdf_export/export_card/card_element.rb
@@ -38,7 +38,7 @@ module OpenProject::PdfExport::ExportCard
       RowElement.prune_empty_groups(@groups_config, work_package)
 
       # NEW
-      all_heights = assign_all_heights_new(@groups_config)
+      all_heights = assign_all_heights(@groups_config)
       reduce_rows(all_heights)
 
       text_padding = @orientation[:text_padding]
@@ -67,25 +67,32 @@ module OpenProject::PdfExport::ExportCard
       end
     end
 
-    def assign_all_heights_new(groups)
+    def assign_all_heights(groups)
       available = @orientation[:height] - (@orientation[:group_padding] * 2)
-      group_heights = Array.new
-      row_heights = Array.new
+      group_heights = []
+      row_heights = []
 
       groups.each_with_index do |(gk, gv), i|
-        enforced_group_height = gv["height"] || -1
+        enforced_group_height = gv["height"] || 0
         used_group_height = 0
+        current_rows = []
 
         gv["rows"].each do |rk, rv|
           if rv["height"]
             used_group_height += rv["height"]
-            row_heights << { height: rv["height"], group: i, priority: rv["priority"] || 10 }
+            current_rows << { height: rv["height"], group: i, priority: rv["priority"] || 10 }
           else
             used_group_height += min_row_height(rv)
-            row_heights << { height: min_row_height(rv), group: i, priority: rv["priority"] || 10 }
+            current_rows << { height: min_row_height(rv), group: i, priority: rv["priority"] || 10 }
           end
         end
 
+        if free_space = enforced_group_height - used_group_height and free_space > 0
+            # Increase height of heighest priority row
+          (current_rows.sort_by{ |r| r[:priority]}.first)[:height] += free_space
+        end
+
+        row_heights |= current_rows
         group_heights << [used_group_height, enforced_group_height].max
       end
 


### PR DESCRIPTION
Like in the example with "description", it will now fill all the free space in the group. Note that text trucation still isn't rendering correctly, will fix this on a different branch.
