### PR TITLE
Monkey patching WorkPackage model to have extra display properties.

### DIFF
--- a/lib/open_project/pdf_export/export_card/document_generator.rb
+++ b/lib/open_project/pdf_export/export_card/document_generator.rb
@@ -26,6 +26,7 @@
 require 'prawn'
 
 module OpenProject::PdfExport::ExportCard
+  require "open_project/pdf_export/export_card/model_display/work_package_display"
   class DocumentGenerator
 
     attr_reader :config

--- a/lib/open_project/pdf_export/export_card/document_generator.rb
+++ b/lib/open_project/pdf_export/export_card/document_generator.rb
@@ -36,6 +36,8 @@ module OpenProject::PdfExport::ExportCard
     attr_reader :paper_height
 
     def initialize(config, work_packages)
+      patch_models
+
       defaults = { page_size: "A4" }
 
       @config = config
@@ -92,6 +94,11 @@ module OpenProject::PdfExport::ExportCard
           card_y_offset -= (card_height + card_padding)
         end
       end
+    end
+
+    def patch_models
+      # Note: Can't seem to patch the models when initializing for reasons which I don't understand
+      WorkPackage.send(:include, WorkPackageDisplay)
     end
   end
 end

--- a/lib/open_project/pdf_export/export_card/model_display/work_package_display.rb
+++ b/lib/open_project/pdf_export/export_card/model_display/work_package_display.rb
@@ -1,0 +1,5 @@
+module WorkPackageDisplay
+  def display_id
+    "#{(kind.is_standard) ? "" : "#{kind.name}"} ##{id}"
+  end
+end


### PR DESCRIPTION
This doesn't feel nice, but I really didn't want to put model specific methods inside the element classes. Tried to put this code in an initializer but it complains about acts_as_journalized, I'm guessing something to do with the ordering of the includes.
