### PR TITLE
Text size cleanup

### DIFF
--- a/lib/open_project/pdf_export/export_card/column_element.rb
+++ b/lib/open_project/pdf_export/export_card/column_element.rb
@@ -101,7 +101,16 @@ module OpenProject::PdfExport::ExportCard
       text_box = Prawn::Text::Formatted::Box.new(texts, options)
       left_overs = text_box.render(:dry_run => true)
       text = texts[1][:text]
-      left_overs.count > 0 ? text.slice(0,text.index(left_overs.first[:text]) - 5) + "[...]" : text
+      if left_overs.count > 0
+        if pos = text.index(left_overs.first[:text]) and !!pos && pos >= 5
+          text.slice(0, pos - 5) + "[...]"
+        else
+          # Text box is too small to fit anything in - just return empty string.
+          ""
+        end
+      else
+        text
+      end
     rescue Prawn::Errors::CannotFit
       ''
     end

--- a/lib/open_project/pdf_export/export_card/column_element.rb
+++ b/lib/open_project/pdf_export/export_card/column_element.rb
@@ -106,15 +106,13 @@ module OpenProject::PdfExport::ExportCard
         overflow = :truncate
         font_size = Integer(@config['font_size'])
 
-      elsif @config['min_font_size']
-        # Range given
-        overflow = :shrink_to_fit
-        min_font_size = Integer(@config['min_font_size'])
-        font_size = if @config['max_font_size']
-                      Integer(@config['max_font_size'])
-                    else
-                      min_font_size
-                    end
+        if @config['min_font_size']
+          # Range given
+          overflow = :shrink_to_fit
+          min_font_size = Integer(@config['min_font_size'])
+        else
+          min_font_size = font_size
+        end
       else
         # Default
         font_size = 12
@@ -126,8 +124,8 @@ module OpenProject::PdfExport::ExportCard
 
       # Label and text
       @has_label = @config['has_label']
+      @default_label_font_size = 12
       indented = @config['indented']
-
 
       # Flatten value to a display string
       display_value = value
@@ -145,7 +143,7 @@ module OpenProject::PdfExport::ExportCard
            :at => offset,
            :style => :bold,
            :overflow => overflow,
-           :size => font_size,
+           :size => @default_label_font_size,
            :min_font_size => min_font_size,
            :align => :left})
 


### PR DESCRIPTION
Font size ranges now work, but not if the field has a label and it is not indented. This is because the prawn formatted text box does not accept font ranges. This is a bit annoying but I think it's a limitation of prawn which I don't see a way round right now.

Text truncation is now working (I hope) with non-indented labelled fields.
