### PR TITLE
remove obsolete header_tags

### DIFF
--- a/app/views/export_card_configurations/index.html.erb
+++ b/app/views/export_card_configurations/index.html.erb
@@ -24,9 +24,6 @@ See doc/COPYRIGHT.md for more details.
 
 ++#%>
 
-
-<%= header_tags %>
-
 <div class="contextual">
 <%= link_to l(:label_export_card_configuration_new), {:action => 'new'}, :class => 'icon icon-add' %>
 </div>


### PR DESCRIPTION
WP [#19652](https://community.openproject.org/work_packages/19652)

this is most likely a copy & paste artifact:

commit 0eba424adf342a9d1f5ca6f75b4c720b30a10ca2
Date:   Tue Jan 21 11:45:09 2014 +0100

```
did some copy pasting to get configs crud to look like other admin
```

sections.

So it seems this was the `header_tags` helper from timelines which was removed [recently](https://github.com/opf/openproject/commit/eb21b4434b6da29787d0dabe608e251c8e18c839#diff-073bd38d2a71d993e2d3a3dc983e4017L106). It didn't do anything useful there. Which makes sense considering it came from timelines and the CSS was targeted at those.

Everything looks and works ok without it.
