### PR TITLE
[22107] Apply new icon styling (PDF Export)

### DIFF
--- a/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -3,7 +3,7 @@
 </div>
 <div class="form--field-instructions">
   <span class="help">
-    <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=850, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
+    <a href="https://github.com/finnlabs/openproject-pdf_export#usage" class="icon icon-help1" onclick="window.open('https://github.com/finnlabs/openproject-pdf_export#usage', '', 'resizable=yes, location=no, width=850, height=800, menubar=no, status=no, scrollbars=yes'); return false;">
       <%= l('help_link_rows_format') %>
     </a>
   </span>

--- a/app/views/export_card_configurations/edit.html.erb
+++ b/app/views/export_card_configurations/edit.html.erb
@@ -33,6 +33,6 @@ See doc/COPYRIGHT.md for more details.
 <%= labelled_tabular_form_for @config, url: pdf_export_export_card_configuration_path(@config) do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>
   <hr class="form--separator">
-  <%= styled_button_tag l(:button_save), class: "-highlight -with-icon icon-yes" %>
+  <%= styled_button_tag l(:button_save), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>
 

--- a/app/views/export_card_configurations/new.html.erb
+++ b/app/views/export_card_configurations/new.html.erb
@@ -33,5 +33,5 @@ See doc/COPYRIGHT.md for more details.
 <%= labelled_tabular_form_for @config, url: pdf_export_export_card_configurations_path do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>
   <hr class="form--separator">
-  <%= styled_button_tag l(:button_create), class: "-highlight -with-icon icon-yes" %>
+  <%= styled_button_tag l(:button_create), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with opf/openproject#3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22107/activity
