### PR TITLE
[23052] Double Breadcrumb in administration (PDF Export)

### DIFF
--- a/app/views/export_card_configurations/edit.html.erb
+++ b/app/views/export_card_configurations/edit.html.erb
@@ -28,7 +28,9 @@ See doc/COPYRIGHT.md for more details.
 
 <%= error_messages_for 'config' %>
 
-<h2><%= link_to t(:label_export_card_configuration_plural), pdf_export_export_card_configurations_path %> &#187; <%= h(@config.name) %></h2>
+<% local_assigns[:additional_breadcrumb] = @config.name %>
+
+<%= breadcrumb_toolbar @config.name %>
 
 <%= labelled_tabular_form_for @config, url: pdf_export_export_card_configuration_path(@config) do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/export_card_configurations/new.html.erb
+++ b/app/views/export_card_configurations/new.html.erb
@@ -28,7 +28,9 @@ See doc/COPYRIGHT.md for more details.
 
 <%= error_messages_for 'config' %>
 
-<h2><%= link_to t(:label_export_card_configuration_plural), pdf_export_export_card_configurations_path %> &#187; <%= t(:label_export_card_configuration_new) %></h2>
+<% local_assigns[:additional_breadcrumb] = t(:label_export_card_configuration_new) %>
+
+<%= breadcrumb_toolbar t(:label_export_card_configuration_new) %>
 
 <%= labelled_tabular_form_for @config, url: pdf_export_export_card_configurations_path do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>


### PR DESCRIPTION
This changes toolbar and breadcrumb elements in the admin view. The doubled information was removed.

Core PR: opf/openproject#4370

https://community.openproject.com/work_packages/23052/activity
