### PR TITLE
[23980] Add buttons are not consistently used (PDF Export)

### DIFF
--- a/app/views/export_card_configurations/index.html.erb
+++ b/app/views/export_card_configurations/index.html.erb
@@ -125,8 +125,11 @@ See doc/COPYRIGHT.md for more details.
   </div>
 </div>
 <div class="generic-table--action-buttons">
-  <%= link_to({action: 'new'}, class: 'button -alt-highlight') do %>
+  <%= link_to({action: 'new'},
+        { class: 'button -alt-highlight',
+          aria: {label: t(:label_export_card_configuration_new)},
+          title: t(:label_export_card_configuration_new)}) do %>
     <i class="button--icon icon-add"></i>
-    <span class="button--text"><%= l(:label_export_card_configuration_new) %></span>
+    <span class="button--text"><%= t(:label_export_card_configuration) %></span>
   <% end %>
 </div>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:
- https://github.com/finnlabs/openproject-backlogs/pull/230
- https://github.com/finnlabs/openproject-my_project_page/pull/83
- https://github.com/opf/openproject-documents/pull/64
- https://github.com/finnlabs/openproject-global_roles/pull/64
- https://github.com/finnlabs/openproject-meeting/pull/133
- https://github.com/opf/openproject/pull/4879
