### PR TITLE
[24676] Breadcrumb link missing (PDF Export)

### DIFF
--- a/app/controllers/export_card_configurations_controller.rb
+++ b/app/controllers/export_card_configurations_controller.rb
@@ -110,4 +110,14 @@ class ExportCardConfigurationsController < ApplicationController
   def load_configs
     @configs = ExportCardConfiguration.all
   end
+
+  protected
+
+  def default_breadcrumb
+    if action_name == 'index'
+      t('label_export_card_configuration')
+    else
+      ActionController::Base.helpers.link_to(t('label_export_card_configuration'), pdf_export_export_card_configurations_path)
+    end
+  end
 end


### PR DESCRIPTION
Similar to https://github.com/opf/openproject/pull/5215 this adds a missing breadcrumb link.

https://community.openproject.com/projects/openproject/work_packages/24676/activity