### PR TITLE
[24899] Hide breadcrumb when not necessary (PDF Export)

### DIFF
--- a/app/controllers/export_card_configurations_controller.rb
+++ b/app/controllers/export_card_configurations_controller.rb
@@ -93,6 +93,10 @@ class ExportCardConfigurationsController < ApplicationController
     redirect_to :action => 'index'
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   private
 
   def cannot_update_default


### PR DESCRIPTION
This shows the breadcrumb in the admin page.

According PRs:
* https://github.com/opf/openproject/pull/5281
* https://github.com/finnlabs/openproject-costs/pull/281
* https://github.com/finnlabs/openproject-zacero/pull/77